### PR TITLE
Replace "app" with "" in RimWorld executable select box

### DIFF
--- a/src/views/Paths.vue
+++ b/src/views/Paths.vue
@@ -59,7 +59,7 @@ export default Vue.extend({
         setRimworldPath: async function(){
             const chosenPath = await remote.dialog.showOpenDialog({
                  properties: ['openFile'],
-                 filters: [{ name: "RimWorld executable", extensions: [ "exe", "app" ] }] });
+                 filters: [{ name: "RimWorld executable", extensions: [ "exe", "" ] }] });
             if( !chosenPath.canceled && chosenPath?.filePaths?.[0] ){
                 store.commit("paths/setPath", { type: "rimworldPath", path: chosenPath.filePaths[0] });
 


### PR DESCRIPTION
Fixes #2 
Rather than accepting a .app as the RimWorld executable, accept something extensionless.

Reasoning:
On macOS, .apps are actually folders that contain the contents of the application. This works against both the fact that the app expects the RimWorld executable to be a file, and the app attempting to launch the executable. Instead, the app would want the actual RimWorld executable itself, which would be a UNIX executable inside the app. UNIX executables are extensionless, so the program should accept extensionless files.

Alternatives:
Accept .app, but when you get an app, instead set the path to `{givenPath}/Contents/MacOS/RimWorld by Ludeon Studios`, which should be the executable itself.